### PR TITLE
Make awk for version capturing more specific

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,9 +51,9 @@ runs:
 
     - if: contains(fromJSON('["release"]'), github.event_name)
       uses: actions/setup-python@v4
-      name: Set up Python 3.9
+      name: Set up Python 3.11
       with:
-        python-version: "3.9"
+        python-version: "3.11"
 
     - if: contains(fromJSON('["release"]'), github.event_name)
       name: Ensure package version and tag are equal
@@ -65,7 +65,7 @@ runs:
           PKG_VER="$(python setup.py --version)"
         elif [ -f "pyproject.toml" ]
         then
-          version=$(awk -F "=" '/^version =/ {print $2}' pyproject.toml | tr -d ' \t\n\r"')
+          version=$(python3.11 -c "import tomllib; print(tomllib.loads(open('pyproject.toml').read())['project']['version'])")
           PKG_VER=$version
         else
           echo "Neither setup.py nor pyproject.toml were found." >&2; exit 1

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
           PKG_VER="$(python setup.py --version)"
         elif [ -f "pyproject.toml" ]
         then
-          version=$(python3.11 -c "import tomllib; print(tomllib.loads(open('pyproject.toml').read())['project']['version'])")
+          version=$(python3.11 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
           PKG_VER=$version
         else
           echo "Neither setup.py nor pyproject.toml were found." >&2; exit 1

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
           PKG_VER="$(python setup.py --version)"
         elif [ -f "pyproject.toml" ]
         then
-          version=$(awk -F "=" '/version/ {print $2}' pyproject.toml | tr -d ' \t\n\r"')
+          version=$(awk -F "=" '/^version =/ {print $2}' pyproject.toml | tr -d ' \t\n\r"')
           PKG_VER=$version
         else
           echo "Neither setup.py nor pyproject.toml were found." >&2; exit 1

--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -1,2 +1,7 @@
 [project]
 version = "0.0.0"
+[tool.ruff]
+target-version = "py39"
+[tool.pytest.ini_options]
+minversion = "7.1"
+


### PR DESCRIPTION
Capturing the package version from pyproject.toml files was not accurate enough and matched other fields in the file too.

See conflicting workflow run: 
https://github.com/ghga-de/test-oidc-provider/actions/runs/7449188466/job/20265264153

```
Package version is 1.1.0py397.1
Tag version is 1.1.0
Package version and tag name mismatch.
```
