### PR TITLE
Add `ignore_trivy` to continue on error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,12 +41,12 @@ inputs:
     default: "false"
   dockerhub_platforms:
       description: "Platforms passed to DockerHub build and push action."
-      default: "linux/amd64"
+      default: "linux/arm64,linux/arm64"
 
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Check out code
 
     - if: contains(fromJSON('["release"]'), github.event_name)
@@ -87,25 +87,25 @@ runs:
           exit 1
         fi
 
-    - uses: docker/setup-qemu-action@v2
+    - uses: docker/setup-qemu-action@v3
       name: Set up QEMU
 
-    - uses: docker/setup-buildx-action@v2
+    - uses: docker/setup-buildx-action@v3
       name: Set up Docker Buildx
 
-    - uses: docker/login-action@v2
+    - uses: docker/login-action@v3
       name: Login to DockerHub
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}
 
     # Existing Docker build step modified to not push
-    - uses: docker/build-push-action@v4
+    - uses: docker/build-push-action@v5
       name: Build (but not push)
       with:
         push: false
         load: true # Ensure the built image is loaded into Docker's local registry for scanning
-        platforms: "${{ inputs.dockerhub_platforms }}"
+        platforms: linux/arm64 # Only build for ARM64 for now
         tags: "${{ inputs.dockerhub_namespace }}/${{ github.event.repository.name }}:${{ inputs.tag }}"
         context: "${{ inputs.working_directory }}"
 
@@ -123,10 +123,10 @@ runs:
     # New step to push the Docker image only if Trivy scan passes
     - name: Push to DockerHub
       if: success() # This ensures the push only happens if previous steps (including Trivy scan) succeeded
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         push: true
-        platforms: "${{ inputs.dockerhub_platforms }}"
+        platforms: "${{ inputs.dockerhub_platforms }}" # Now build for all platforms
         tags: "${{ inputs.dockerhub_namespace }}/${{ github.event.repository.name }}:${{ inputs.tag }}"
         context: "${{ inputs.working_directory }}"
 

--- a/action.yml
+++ b/action.yml
@@ -99,11 +99,12 @@ runs:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_token }}
 
+    # Existing Docker build step modified to not push
     - uses: docker/build-push-action@v4
-      name: Build and push
-      id: docker_build
+      name: Build (but not push)
       with:
-        push: true
+        push: false
+        load: true # Ensure the built image is loaded into Docker's local registry for scanning
         platforms: "${{ inputs.dockerhub_platforms }}"
         tags: "${{ inputs.dockerhub_namespace }}/${{ github.event.repository.name }}:${{ inputs.tag }}"
         context: "${{ inputs.working_directory }}"
@@ -111,13 +112,23 @@ runs:
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
       with:
-        image-ref: "docker.io/${{ inputs.dockerhub_namespace }}/${{ github.event.repository.name }}:${{ inputs.tag }}"
+        image-ref: "${{ inputs.dockerhub_namespace }}/${{ github.event.repository.name }}:${{ inputs.tag }}"
         format: "table"
         exit-code: "1"
         ignore-unfixed: true
         vuln-type: "os,library"
         severity: ${{ inputs.trivy_severity }}
       continue-on-error: ${{ inputs.ignore_trivy }}
+
+    # New step to push the Docker image only if Trivy scan passes
+    - name: Push to DockerHub
+      if: success() # This ensures the push only happens if previous steps (including Trivy scan) succeeded
+      uses: docker/build-push-action@v4
+      with:
+        push: true
+        platforms: "${{ inputs.dockerhub_platforms }}"
+        tags: "${{ inputs.dockerhub_namespace }}/${{ github.event.repository.name }}:${{ inputs.tag }}"
+        context: "${{ inputs.working_directory }}"
 
     - name: Image digest
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
     default: "false"
   dockerhub_platforms:
       description: "Platforms passed to DockerHub build and push action."
-      default: "linux/amd64,linux/arm64"
+      default: "linux/amd64"
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,7 @@ runs:
         ignore-unfixed: true
         vuln-type: "os,library"
         severity: ${{ inputs.trivy_severity }}
-      continue-on-error: ${{ inputs.ignore_trivy }}
+      continue-on-error: ${{ inputs.ignore_trivy == 'true' }}
 
     # New step to push the Docker image only if Trivy scan passes
     - name: Push to DockerHub

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   trivy_severity:
     description: "Severities of vulnerabilities to scanned for and displayed."
     default: "CRITICAL,HIGH"
+  ignore_trivy:
+    description: "Whether to ignore Trivy vulnerabilities."
+    default: "false"
   dockerhub_platforms:
       description: "Platforms passed to DockerHub build and push action."
       default: "linux/amd64,linux/arm64"
@@ -114,6 +117,7 @@ runs:
         ignore-unfixed: true
         vuln-type: "os,library"
         severity: ${{ inputs.trivy_severity }}
+      continue-on-error: ${{ inputs.ignore_trivy }}
 
     - name: Image digest
       shell: bash


### PR DESCRIPTION
This PR introduces the `ignore_trivy` input parameter to the `gh-action-ci` GitHub Action. This new parameter allows workflows to continue even when the Trivy vulnerability scanner identifies issues, effectively making Trivy scans advisory rather than blocking. Additionally, this update includes version bumps for several actions used within the workflow and refines the Docker build and push process to conditionally build only for ARM64 initially, and then for all specified platforms if the Trivy scan succeeds.

## Changes

- Added `ignore_trivy` input to control whether the workflow should fail on Trivy scan failures.
- Updated actions:
  - `actions/checkout` to v4
  - `docker/setup-qemu-action` to v3
  - `docker/setup-buildx-action` to v3
  - `docker/login-action` to v3
  - `docker/build-push-action` to v5
- Modified Docker build step to initially avoid pushing the image, instead loading it into Docker's local registry for scanning.
- Introduced a conditional push step that triggers only if the Trivy scan passes, ensuring images are only published after a successful security check.
- Adjusted the `platforms` input for the initial Docker build step to `linux/arm64`, focusing on ARM64 architecture to expedite the scanning process.
- Refined the workflow to build for all specified platforms only after a successful Trivy scan.

## Rationale

This enhancement provides greater flexibility in handling vulnerability scan results from Trivy, allowing developers to decide whether to treat scan failures as blockers for their CI/CD pipeline. It's particularly useful for workflows where vulnerabilities are assessed in a broader context, and immediate fixes may not be feasible due to various reasons such as false positives, risk acceptance, or planned remediation in future releases.

By updating various actions to their latest versions, we also ensure that our workflows benefit from the latest features, performance improvements, and security patches.

The decision to initially build only for `linux/arm64` before scanning and subsequently for all platforms upon a successful scan optimizes workflow run times and resource usage, balancing thoroughness with efficiency.

## Impact

This update requires users to explicitly set the `ignore_trivy` parameter according to their workflow requirements. The default behavior remains unchanged (i.e., workflows will fail on Trivy scan failures unless `ignore_trivy` is set to `true`).

## Testing

- [x] Verify that the workflow successfully continues despite Trivy scan failures when `ignore_trivy` is set to `true`.
see: https://github.com/ghga-de/auth-service/actions/runs/8064432398/job/22028309467
- [x] Confirm that Docker images are only pushed if the Trivy scan passes.
see: https://github.com/ghga-de/auth-service/actions/runs/8065150794/job/22030392622
- [x] Ensure compatibility and expected behavior with updated action versions.
