### PR TITLE
Specify Trivy DB repository

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,8 @@ runs:
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master
+      env:
+        TRIVY_DB_REPOSITORY: "ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db"
       with:
         image-ref: "docker.io/${{ inputs.dockerhub_namespace }}/${{ github.event.repository.name }}:${{ inputs.tag }}${{ steps.get_suffixes.outputs.tag_suffix }}"
         format: "table"


### PR DESCRIPTION
There are these discussions about the Trivy issue where it fails when downloading DB from the default repository: https://github.com/aquasecurity/trivy/discussions/7668 and https://github.com/aquasecurity/trivy-action/issues/389.

There is a PR recently merged: https://github.com/aquasecurity/trivy-action/pull/433 This should solve the issue when released, but also specifying an alternative DB increases the robustness of this step. https://github.com/aquasecurity/trivy/discussions/7668#discussioncomment-10879681 If you specify multiple DB repositories, Trivy retries the next one if the primary repository fails. There are three repositories for Trivy DB, and they are updated every 6 hours together.

Already applied and tested in monorepo: https://github.com/ghga-de/file-services-backend/pull/72
