### PR TITLE
Install setuptools before extracting python package version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,7 @@ runs:
         if [ -f "setup.py" ]
         then
           echo "Using setup.py to extract python package version"
+          pip install setuptools
           PKG_VER="$(python setup.py --version)"
         elif [ -f "pyproject.toml" ]
         then


### PR DESCRIPTION
The CI doesn't run currently in `auth-km-jobs`:
https://github.com/ghga-de/auth-km-jobs/actions/runs/12316091324

It fails because of the missing dependency `setuptools` while extracting the package version from `setup.py`.

This PR adds the installation of the  dependency before extracting the package version.